### PR TITLE
Update pbr: warn_dhcp_force

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -25,6 +25,8 @@ readonly _OKB_='\033[1;34m\xe2\x9c\x93\033[0m'
 readonly __OKB__='\033[1;34m[\xe2\x9c\x93]\033[0m'
 readonly _FAIL_='\033[0;31m\xe2\x9c\x97\033[0m'
 readonly __FAIL__='\033[0;31m[\xe2\x9c\x97]\033[0m'
+readonly _WARN_='\033[0;33m!\033[0m'
+readonly __WARN__='\033[0;33m[!]\033[0m'
 readonly _ERROR_='\033[0;31mERROR\033[0m'
 readonly _WARNING_='\033[0;33mWARNING\033[0m'
 readonly ip_full='/usr/libexec/ip-full'
@@ -162,6 +164,10 @@ output() {
 	else
 		printf "%b" "$msg" >> "$sharedMemoryOutput"
 	fi
+}
+warn_dhcp_force(){
+	[ $(uci_get dhcp lan force 0) -eq 0 ] \
+		&& output 3 "WARNING: please enable 'dhcp.lan.force' $__WARN__\\n"
 }
 pbr_find_iface() {
 	local iface i param="$2"
@@ -1124,6 +1130,7 @@ resolver() {
 					fi
 				;;
 				restart)
+					warn_dhcp_force
 					[ -z "$resolver_set_supported" ] && return 1
 					output 3 'Restarting dnsmasq '
 					if /etc/init.d/dnsmasq restart >/dev/null 2>&1; then


### PR DESCRIPTION
Display a warning if user has dhcp.force = 0 (disabled). If disabled a request is put out to identify other DHCP-servers on the network. This takes up time (about 3s ¬ 6s depending on start/stop/restart) and is uncommon for most users.

I could not find a good place to put it because the code is still unfamiliar., so its added to restart to give an idea how it would function.