### PR TITLE
pbr: reverse default route for BROADCAST and POINTOPOINT interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.7
-PKG_RELEASE:=37
+PKG_RELEASE:=41
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1609,9 +1609,9 @@ EOF
 							try ip -6 route add unreachable default table "$tid" || ipv6_error=1
 						elif ip -6 route list table main | grep -q " dev $dev6 "; then
 							if ip -6 address show dev "$dev6" | grep -q "BROADCAST"; then
-								try ip -6 route add default dev "$dev6" table "$tid" metric "$procd_wan6_metric" || ipv6_error=1
+								try ip -6 route add default via "$gw6" dev "$dev6" table "$tid" metric "$procd_wan6_metric" || ipv6_error=1
 							elif ip -6 address show dev "$dev6" | grep -q "POINTOPOINT"; then
-								try ip -6 route add default via "$gw6" dev "$dev6" table "$tid" || ipv6_error=1
+								try ip -6 route add default dev "$dev6" table "$tid" metric "$procd_wan6_metric" || ipv6_error=1
 							else
 								state add 'errorSummary' 'errorInterfaceRoutingUnknownDevType' "$dev6"
 							fi
@@ -1692,9 +1692,9 @@ EOF
 						try ip -6 route add unreachable default table "$tid" || ipv6_error=1
 					elif ip -6 route list table main | grep -q " dev $dev6 "; then
 						if ip -6 address show dev "$dev6" | grep -q "BROADCAST"; then
-							try ip -6 route add default dev "$dev6" table "$tid" metric "$procd_wan6_metric" || ipv6_error=1
+							try ip -6 route add default via "$gw6" dev "$dev6" table "$tid" metric "$procd_wan6_metric" || ipv6_error=1
 						elif ip -6 address show dev "$dev6" | grep -q "POINTOPOINT"; then
-							try ip -6 route add default via "$gw6" dev "$dev6" table "$tid" || ipv6_error=1
+							try ip -6 route add default dev "$dev6" table "$tid" metric "$procd_wan6_metric" || ipv6_error=1
 						else
 							state add 'errorSummary' 'errorInterfaceRoutingUnknownDevType' "$dev6"
 						fi


### PR DESCRIPTION
The setting of default route for BROADCAST and POINTOPOINT interfaces seems reversed

We discussed it briefly and I might have set you off in the wrong direction

This patch should correct that

Tested on Netgear R7800 buil 23.05.5 NSS

Signed-off-by: Erik Conijn egc112@msn.com