### PR TITLE
pbr: fix wrong start

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -561,7 +561,7 @@ load_environment() {
 	}
 	local param="$1" validation_result="$2"
 	case "$param" in
-		on_start)
+		on_start|on_boot)
 			output 1 "Loading environment ($param) "
 			load_package_config "$param"
 			if [ "$enabled" -eq '0' ]; then


### PR DESCRIPTION
Fix for wrong start.

Without this commit a restart is necessary to remove error messages regarding fail to resolv.

Tested on latest snapshot with dnsmasq-full on MT6000