### PR TITLE
Update pbr: ip-full check

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -537,8 +537,10 @@ load_environment() {
 			uci_remove 'firewall' 'defaults' 'auto_includes'
 			uci_commit firewall
 		fi
-		# TODO: implement ip-full check
-		# state add 'errorSummary' 'errorRequiredBinaryMissing' 'ip-full'
+		if [ "$(readlink /sbin/ip)" != "$ip_full" ]; then
+			state add 'errorSummary' 'errorRequiredBinaryMissing' 'ip-full'
+			_ret='1'
+		fi
 		if ! nft_call list table inet fw4; then
 			state add 'errorSummary' 'errorDefaultFw4TableMissing' 'fw4'
 			_ret='1'


### PR DESCRIPTION
You already had ip_full specified in the readonly section, so used that as base. Then implemented the comment error message.

Maybe its better to suggest a package to install as they contain the binary. Sometimes they are not the same.