### PR TITLE
pbr: netifd set ipv4 and ipv6 default route for pbr netifd tables

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2223,6 +2223,20 @@ setup_netifd() {
 			fi
 			uci_set 'network' "${iface}" 'ip4table' "${ipTablePrefix}_${iface%6}"
 			uci_set 'network' "${iface}" 'ip6table' "${ipTablePrefix}_${iface%6}"
+
+			_pbr_netifd_set_defrt() {
+				local IPV="$1"
+				output "Setting up ${packageName} default IP${IPV} route for ${iface} "
+				uci_add 'network' 'route' "${ipTablePrefix}_${iface%6}_${IPV}"
+				uci_set 'network' "${ipTablePrefix}_${iface%6}_${IPV}" 'interface' "${iface%6}"
+				if [ "$IPV" = "6" ]; then
+					uci_set 'network' "${ipTablePrefix}_${iface%6}_${IPV}" 'target' '::0/0'
+				else
+					uci_set 'network' "${ipTablePrefix}_${iface%6}_${IPV}" 'target' '0.0.0.0/0'
+				fi
+			}
+			_pbr_netifd_set_defrt 4
+			[ $(uci -q get pbr.config.ipv6_enabled) -eq 1 ] && _pbr_netifd_set_defrt 6
 			output_okbn
 		fi
 	}


### PR DESCRIPTION
Patch to always set ipv4 and ipv6 default routes for netifd pbr tables

Use this patch as you seem fit, change or move it etc. if you want

Still struggling with netifd.
If you have a VPN as default route and you stop the VPN the default route will still try to go through the VPN as that is not reversed. Furthermore I see my endpoint for the VPN routed via another VPN which is not working if I do not have the WAN as default.

For now it looks like with netifd it only works reliably if you keep the WAN as default. That is now possible with this patch as there will be a default route made in the pbr netifd tables

Tested on R7800  23.05.5 NSS build

Signed-off-by: Erik Conijn egc112@msn.com