### PR TITLE
Update pbr: remove sync slowdown ?

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -891,7 +891,6 @@ cleanup_rt_tables() {
 	for i in $(grep -oh "${ipTablePrefix}_.*" $rtTablesFile); do
 		! is_netifd_table "$i" && sed -i "/${i}/d" "$rtTablesFile"
 	done
-	sync
 }
 
 cleanup_main_chains() {
@@ -1702,9 +1701,7 @@ interface_routing() {
 			else
 				if ! grep -q "$tid ${ipTablePrefix}_${iface}" "$rtTablesFile"; then
 					sed -i "/${ipTablePrefix}_${iface}/d" "$rtTablesFile"
-					sync
 					echo "$tid ${ipTablePrefix}_${iface}" >> "$rtTablesFile"
-					sync
 				fi
 				ip -4 rule del table "$tid" >/dev/null 2>&1
 				ip -4 route flush table "$tid" >/dev/null 2>&1
@@ -1786,7 +1783,6 @@ EOF
 			if ! is_netifd_table_interface "$iface"; then
 				ip route flush table "$tid" >/dev/null 2>&1
 				sed -i "/${ipTablePrefix}_${iface}\$/d" "$rtTablesFile"
-				sync
 			fi
 			return "$s"
 		;;


### PR DESCRIPTION
What's the reason to use sync? Most of it runs in-memory or on a tmpfs. If you let Linux handle it will save about ~5 seconds in a restart.

I only see it used in the following init files with a good reason:
* boot: to cement initial config generation.
* done: after removal of sysupgrade (substantial file size)
* uhttpd to cement the certificate
* umount to cement pending writes

I experience no issues by removing them.

before:
```
real	0m 7.62s
user	0m 1.31s
sys	0m 0.37s
```

after:
```
real	0m 2.37s
user	0m 1.33s
sys	0m 0.40s
```