### PR TITLE
Update pbr: made "enabled" compatible with initrc and service (depends on second patch in luci-app-pbr)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,10 @@ define Package/pbr/postinst
 		chmod -x /etc/init.d/pbr || true
 		fw4 -q reload || true
 		chmod +x /etc/init.d/pbr || true
+		[ -f "/tmp/pbr-enabled" ] || break
 		echo -n "Installing rc.d symlink for pbr... "
 		/etc/init.d/pbr enable && echo "OK" || echo "FAIL"
+		/etc/init.d/pbr enabled && rm "/tmp/pbr-enabled"		
 	fi
 	exit 0
 endef
@@ -114,6 +116,7 @@ define Package/pbr/prerm
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
 		uci -q delete firewall.pbr || true
+		/etc/init.d/pbr enabled && touch "/tmp/pbr-enabled"
 		echo -n "Stopping pbr service... "
 		/etc/init.d/pbr stop quiet >/dev/null 2>&1 && echo "OK" || echo "FAIL"
 		echo -n "Removing rc.d symlink for pbr... "
@@ -138,8 +141,10 @@ define Package/pbr-netifd/postinst
 		chmod -x /etc/init.d/pbr || true
 		fw4 -q reload || true
 		chmod +x /etc/init.d/pbr || true
+		[ -f "/tmp/pbr-netifd-enabled" ] || break
 		echo -n "Installing rc.d symlink for pbr-netifd... "
 		/etc/init.d/pbr enable && echo "OK" || echo "FAIL"
+		/etc/init.d/pbr enabled && rm "/tmp/pbr-netifd-enabled"		
 	fi
 	exit 0
 endef
@@ -148,6 +153,7 @@ define Package/pbr-netifd/prerm
 	#!/bin/sh
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
+		/etc/init.d/pbr enabled && touch "/tmp/pbr-netifd-enabled"
 		uci -q delete firewall.pbr || true
 		echo -n "Stopping pbr-netifd service... "
 		/etc/init.d/pbr stop quiet >/dev/null 2>&1 && echo "OK" || echo "FAIL"

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2038,7 +2038,8 @@ start_service() {
 	fi
 
 	procd_open_instance 'main'
-	procd_set_param command /bin/true
+	procd_set_param command /bin/sleep '10000d' #temporary workaround
+	procd_set_param pidfile $packageLockFile
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_open_data
@@ -2133,7 +2134,6 @@ service_started() {
 	fi
 	state print 'errorSummary'
 	state print 'warningSummary'
-	touch "$packageLockFile"
 	if [ -n "$errorSummary" ]; then
 		return 2
 	elif [ -n "$warningSummary" ]; then
@@ -2200,7 +2200,6 @@ stop_service() {
 			output "$serviceName (nft mode) stopped "; output_okn;
 		fi
 	fi
-	rm -f "$packageLockFile"
 }
 
 version() { echo "$PKG_VERSION"; }
@@ -2401,5 +2400,3 @@ load_validate_include() {
 		'path:file' \
 		'enabled:bool:0'
 }
-
-service_running(){ [ -f "$packageLockFile" ];}

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -48,7 +48,6 @@ readonly rtTablesFile='/etc/iproute2/rt_tables'
 
 # package config options
 procd_boot_timeout=
-enabled=
 fw_mask=
 icmp_interface=
 ignored_interface=
@@ -298,7 +297,6 @@ uci_get_listen_port() {
 }
 
 # luci app specific
-is_enabled() { uci_get "$1" 'config' 'enabled'; }
 is_running_nft_file() { [ -s "$nftPermFile" ]; }
 is_running_nft() { "$nft" list table inet fw4 | grep chain | grep -q pbr_mark_ >/dev/null 2>&1; }
 check_nft() { [ -x "$nft" ]; }
@@ -347,7 +345,6 @@ get_text() {
 		errorConfigValidation) r="Config ($packageConfigFile) validation failure!";;
 		errorNoNft) r="Resolver set support (${resolver_set}) requires nftables, but nft binary cannot be found!";;
 		errorResolverNotSupported) r="Resolver set (${resolver_set}) is not supported on this system!";;
-		errorServiceDisabled) r="The ${packageName} service is currently disabled!";;
 		errorNoWanGateway) r="The ${serviceName} service failed to discover WAN gateway!";;
 		errorNoWanInterface) r="The %s interface not found, you need to set the 'pbr.config.procd_wan_interface' option!";;
 		errorNoWanInterfaceHint) r="Refer to https://docs.openwrt.melmac.net/pbr/#procd_wan_interface.";;
@@ -442,7 +439,6 @@ load_package_config() {
 	local param="$1"
 	local user_file_check_result i
 	config_load "$packageName"
-	config_get_bool enabled                   'config' 'enabled' '0'
 	config_get      fw_mask                   'config' 'fw_mask' 'ff0000'
 	config_get      icmp_interface            'config' 'icmp_interface'
 	config_get      ignored_interface         'config' 'ignored_interface'
@@ -552,11 +548,6 @@ load_environment() {
 		on_boot|on_start)
 			output 1 "Loading environment ($param) "
 			load_package_config "$param"
-			if [ "$enabled" -eq '0' ]; then
-				output 1 "$_FAIL_\n"
-				state add 'errorSummary' 'errorServiceDisabled'
-				return 1
-			fi
 			if [ -n "$validation_result" ] && [ "$validation_result" != '0' ]; then
 				output 1 "$_FAIL_\n"
 				output "${_ERROR_}: The $packageName config validation failed!\n"
@@ -2202,7 +2193,7 @@ stop_service() {
 	resolver 'store_hash'
 	resolver 'cleanup_all'
 	resolver 'compare_hash' && resolver 'restart'
-	if [ "$enabled" -ne '0' ]; then
+	if enabled; then
 		if [ -n "$nft_file_mode" ]; then
 			output "$serviceName (fw4 nft file mode) stopped "; output_okn;
 		else
@@ -2410,3 +2401,5 @@ load_validate_include() {
 		'path:file' \
 		'enabled:bool:0'
 }
+
+service_running(){ [ -f "$packageLockFile" ];}


### PR DESCRIPTION
This makes PBR compatible with initrc and service. but depends on another [patch](https://github.com/stangri/luci-app-pbr/pull/1/commits/0e5a59f3489a6f7e26e9e21d1eafea67357c8b8b) for luci-app-pbr to make it function.
Changes:
* new readonly variable startOnBoot
* removed variable enabled (obsolete)
* changed <del>removed</del> function is_enabled
* removed config_get_bool enable (obsolete)
* changed function load_environment
* <del>removed $enabled entries 6x</del>
* <del>new function: enable() to enable the service</del>
* <del>new function: disable() to disable the service</del>
