### PR TITLE
pbr: is_domain, allow hyphen

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -214,7 +214,7 @@ uci_get_device() {
 uci_get_protocol() { uci_get 'network' "$1" 'proto'; }
 is_default_dev() { [ "$1" = "$(ip -4 r | grep -m1 'dev' | grep -Eso 'dev [^ ]*' | awk '{print $2}')" ]; }
 is_disabled_interface() { [ "$(uci_get 'network' "$1" 'disabled')" = '1' ]; }
-is_domain(){ echo "$1" | grep -qE '^([a-zA-Z0-9]{0,61}[a-zA-Z0-9]\.)*[a-zA-Z]{2,}$'; }
+is_domain(){ echo "$1" | grep -qE '^([a-zA-Z0-9][a-zA-Z0-9-]{0,61}\.)*[a-zA-Z]{2,}$'; }
 is_dslite() { local p; network_get_protocol p "$1"; [ "${p:0:6}" = "dslite" ]; }
 is_family_mismatch() { ( is_ipv4 "${1//!}" && is_ipv6 "${2//!}" ) || ( is_ipv6 "${1//!}" && is_ipv4 "${2//!}" ); }
 is_greater() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }


### PR DESCRIPTION
The current implementation does not allow a hyphen. This patch allows one or more hyphens (in addition to alphanumeric characters) for second and subsequent characters.

A hyphen is allowed but cannot be the first or the last character and although my patch does allow a hyphen as last character, at least it allows a hyphen, so maybe not optimal but at least better. The complete validation is more complex but as this is only used to make a distinction between ip address and domain name, it could be sufficient.

REF: https://cs.uwaterloo.ca/twiki/view/CF/HostNamingRules

Please have a look and consider implementing

Signed-off-by: Erik Conijn egc112@msn.com