### PR TITLE
pbr: enhance status

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2332,14 +2332,19 @@ status_service() {
 	tableCount="$(grep -c "${packageName}_" "$rtTablesFile")" || tableCount=0
 	wan_tid=$(($(get_rt_tables_next_id)-tableCount))
 	i=0; while [ "$i" -lt "$tableCount" ]; do
-		echo "IPv4 table $((wan_tid + i)) route: $(ip -4 route show table $((wan_tid + i)) | grep default)"
-		echo "IPv4 table $((wan_tid + i)) rule(s):"
+		local status_table="$(grep $((wan_tid + i)) "$rtTablesFile")"
+		echo "IPv4 table $status_table route:"
+		ip -4 route show table "$((wan_tid + i))" | grep default
+		echo "IPv4 table $status_table rule(s):"
 		ip -4 rule list table "$((wan_tid + i))"
-		if [ -n "$ipv6_enabled" ]; then
-			echo "IPv6 table $((wan_tid + i)) route: $(ip -6 route show table $((wan_tid + i)) | grep default)"
-			echo "IPv6 table $((wan_tid + i)) rule(s):"
-			ip -6 route show table $((wan_tid + i))
+		if [ "$(uci_get $packageName config ipv6_enabled)" = "1" ]; then
+			echo "$_SEPARATOR_"
+			echo "IPv6 table $status_table route:"
+			ip -6 route show table "$((wan_tid + i))" | grep default
+			echo "IPv6 table $status_table rule(s):"
+			ip -6 rule list table "$((wan_tid + i))"
 		fi
+		echo "$_SEPARATOR_"
 		i=$((i + 1))
 	done
 }


### PR DESCRIPTION
`service pbr status` only displays IPv4 and not IPv6 tables and rules. This seems to be caused by the fact that `$ipv6_enabled` is not available. I devised a workaround getting the variable from the config with `uci_get` Furthermore I changed the code to show the IPv6 rule(s) and added not only the table number but also the table name and added some line breaks for better readability.

Please have a look and consider implementing, feel free to change/improve this pull request 😊

Tested on R7800 running 23.05.5

Signed-off-by: Erik Conijn egc112@msn.com