### PR TITLE
pbr: wg-servers ip-rules not reloaded on reloading interfaces

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -215,7 +215,9 @@ uci_get_device() {
 uci_get_protocol() { uci_get 'network' "$1" 'proto'; }
 is_default_dev() { [ "$1" = "$(ip -4 r | grep -m1 'dev' | grep -Eso 'dev [^ ]*' | awk '{print $2}')" ]; }
 is_disabled_interface() { [ "$(uci_get 'network' "$1" 'disabled')" = '1' ]; }
-is_domain() { echo "$1" | grep -qE "^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$"; }
+#is_domain(){ echo "$1" | grep -qE '^([a-zA-Z0-9][a-zA-Z0-9-]{0,61}\.)*[a-zA-Z]{2,}$'; } #r16
+#is_domain() { echo "$1" | grep -qE "^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$"; }  #r18 does not discern ipv4
+is_domain() { ! is_ipv4 "$1" && echo "$1" | grep -qE "^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$"; }  #egc-r18
 is_dslite() { local p; network_get_protocol p "$1"; [ "${p:0:6}" = "dslite" ]; }
 is_family_mismatch() { ( is_ipv4 "${1//!}" && is_ipv6 "${2//!}" ) || ( is_ipv6 "${1//!}" && is_ipv4 "${2//!}" ); }
 is_greater() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1771,7 +1771,7 @@ process_interface() {
 		disabled="$(uci_get 'network' "$iface" 'disabled')"
 		listen_port="$(uci_get 'network' "$iface" 'listen_port')"
 		case "$action" in
-			create|reload)
+			create|reload|reload_interface)
 				if [ "$disabled" != '1' ] && [ -n "$listen_port" ]; then
 					if [ -n "$wanIface4" ]; then
 						ip rule del sport "$listen_port" table "pbr_${wanIface4}" >/dev/null 2>&1


### PR DESCRIPTION
Maintainer: @stangri

Tested: on Dynalink DL-WRX36 running main build

Description:
Problem reported by: https://forum.openwrt.org/t/policy-based-routing-pbr-package-discussion/140639/2057?u=egc

I also have it sometimes after a reboot when interfaces are still restarting, PBR will reload the interface but not the wg-server ip rules.

This problem can be triggered by doing `service network restart` this will not reinstate the wg-server ip rules.

When doing a `service pbr restart` it works again and the wg-server ip rules are in place.

A possible solution is to reinstate the wg-server iprules not only on boot/restart but also on reloading of interfaces.

After some research the "action" is `reload_interface` so adding that to https://github.com/stangri/pbr/blob/43bdaa096d04883a08d6d1b20cd55248805ed2aa/files/etc/init.d/pbr#L1774 might solve it

Furthermore maybe `reload_interface` should also be added to the tor interface in line?: https://github.com/stangri/pbr/blob/43bdaa096d04883a08d6d1b20cd55248805ed2aa/files/etc/init.d/pbr#L1755

Signed-off-by: Erik Conijn egc112@msn.com