### PR TITLE
Add a user file for bulk resolving domain names from policies

### DIFF
--- a/files/etc/config/pbr
+++ b/files/etc/config/pbr
@@ -34,6 +34,10 @@ config include
 	option path '/usr/share/pbr/pbr.user.netflix'
 	option enabled '0'
 
+config include
+        option path '/usr/share/pbr/pbr.user.dnsprefetch'
+        option enabled '0'
+
 config dns_policy
 	option name 'Redirect Local IP DNS'
 	option src_addr '192.168.1.5'

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -1,0 +1,79 @@
+#!/bin/sh
+# When using pbr with dnsmasq's nft set support, a domain-based policy will not take effect until
+# the remote domain name has been resolved by dnsmasq. Resolve all domain names in pbr policies in advance.
+
+(
+	timeout_nft=10
+	timeout_dnsmasq=20
+	pipe_ubus="/tmp/pipe.ubus.$$"
+	pipe_nslookup="/tmp/pipe.nslookup.$$"
+	log_abort="domain names in policies not resolved"
+
+	output()
+	{
+		local msg="$*"
+		msg="$(printf "%b" "$msg" | sed 's/\x1b\[[0-9;]*m//g')"
+		logger -t "$packageName [$$]" "$(printf "%b" "$msg")"
+	}
+
+	nft_ready()
+	{
+		while ! /usr/sbin/nft list sets inet | grep -q "pbr"; do
+			[ "$timeout_nft" = 0 ] && { output "Pbr's nft sets not found, $log_abort $__FAIL__"; return 1; }
+			sleep 1 && timeout_nft=$((timeout_nft - 1))
+		done
+	}
+
+	run_nslookup()
+	{
+		output="$(nslookup "$1" 127.0.0.1)"
+		[ "$?" = 0 ] && { echo 0 > "$pipe_nslookup"; return; }
+		echo "$output" | grep -q -E "NXDOMAIN|SERVFAIL|timed out" && {
+			reason="$(printf '%s\n' "$output" | grep -Eo "NXDOMAIN|SERVFAIL|timed out" | tail -n1)"
+			output "$_WARNING_ Lookup failed for $domain ($reason)"
+			echo 1 > "$pipe_nslookup"
+		}
+	}
+
+	nslookup_tracker()
+	{
+		while read ec; do
+			entries=$((entries + 1))
+			[ "$ec" = 1 ] && errors=$((errors + 1))
+		done < "$pipe_nslookup"
+		output "Finished resolving $entries domain names in policies (${errors:-0} failed) $__OK__"
+	}
+
+	[ -n "$resolverSetSupported" ] || { output "Resolver set support disabled, $log_abort $__FAIL__"; exit; }
+
+	mkfifo "$pipe_ubus"
+	mkfifo "$pipe_nslookup"
+
+	ubus listen -m "ubus.object.add" > "$pipe_ubus" & ubus_listen_pid=$!
+
+	while read -t "$timeout_dnsmasq" -r event; do
+
+		echo "$event" | grep -q "dnsmasq.dns" || continue
+		dnsmasq_restarted=1
+		[ -f "$dnsmasqFileDefault" ] || { output "File $dnsmasqFileDefault not found, $log_abort $__FAIL__"; break; }
+		nft_ready || break
+		nslookup_tracker & exec 3>"$pipe_nslookup"
+
+		(
+			output "Resolving domain names in policies..."
+			while IFS="/" read -r option domain rest; do
+				[ -n "$domain" ] && run_nslookup "$domain" &
+				entries=$((entries + 1))
+			done < "$dnsmasqFileDefault"
+			wait
+		)
+
+		exec 3>&-
+		break
+	done < "$pipe_ubus"
+
+	[ -n "$dnsmasq_restarted" ] || output "Dnsmasq hasn't restarted, $log_abort $__FAIL__"
+	kill "$ubus_listen_pid"
+	rm "$pipe_ubus"
+	rm "$pipe_nslookup"
+) &


### PR DESCRIPTION
Please review and feel free to make any necessary adjustments.

Before running the main loop of the script, I decided to check for `$resolverSetSupported` instead of `$resolver_set` to avoid edge cases when resolver set support is configured for, but not really available. I'm also not entirely sure a single grep for `pbr` agains the `/usr/sbin/nft list sets inet` output (in the `nft_ready` function) is sufficient to make sure all the nft sets have been added. Let me know if a more robust check is required or anything else needs improvement.